### PR TITLE
One-to-many scenario with videoroomtest.js

### DIFF
--- a/html/videoroomtest.js
+++ b/html/videoroomtest.js
@@ -64,6 +64,7 @@ var bitrateTimer = [];
 
 var doSimulcast = (getQueryStringValue("simulcast") === "yes" || getQueryStringValue("simulcast") === "true");
 var doSimulcast2 = (getQueryStringValue("simulcast2") === "yes" || getQueryStringValue("simulcast2") === "true");
+var subscriber_mode = (getQueryStringValue("subscriber-mode") === "yes")
 
 $(document).ready(function() {
 	// Initialize the library (all console debuggers enabled)
@@ -162,7 +163,13 @@ $(document).ready(function() {
 											myid = msg["id"];
 											mypvtid = msg["private_id"];
 											Janus.log("Successfully joined room " + msg["room"] + " with ID " + myid);
-											publishOwnFeed(true);
+											if (subscriber_mode) {
+                                                						$('#videojoin').hide();
+                                                						$('#videos').removeClass('hide').show();
+                                            						}
+                                            						else
+                                                						publishOwnFeed(true);
+
 											// Any new feed to attach to?
 											if(msg["publishers"]) {
 												var list = msg["publishers"];


### PR DESCRIPTION
A small patch for `videoroomtest` for quick and dirty test of one-to-many scenarios. If you specify the query parameter `subscriber-mode=yes` the local instance will neither touch nor send local media, but instead display the media other publishers provide.